### PR TITLE
Update PHP_CodeSniffer repository link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,6 @@ To test the changes you will obviously need a bot, assuming you already have one
 
 The easiest way to test your changes is to run the bot with `getUpdates` method - use `php bin/console loop` command.
 
-Make sure your code is following PSR-2 coding standard - run [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) with `composer check-code` command.
+Make sure your code is following PSR-2 coding standard - run [PHP_CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer) with `composer check-code` command.
 
 Now when all seems to be good push you changes to a new branch in your fork and then [create a pull request](https://github.com/jacklul/inlinegamesbot/compare) explaining all the changes.


### PR DESCRIPTION
PHP_CodeSniffer has moved to a new GitHub organization. The `squizlabs/PHP_CodeSniffer` repository is now archived and the project is actively maintained at https://github.com/PHPCSStandards/PHP_CodeSniffer.

See: https://github.com/squizlabs/PHP_CodeSniffer/issues/3932